### PR TITLE
Allow coupons in after tax rules

### DIFF
--- a/src/Context/PromotionContext.php
+++ b/src/Context/PromotionContext.php
@@ -13,15 +13,27 @@ namespace MonsieurBiz\SyliusAdvancedPromotionPlugin\Context;
 
 class PromotionContext implements PromotionContextInterface
 {
+    protected bool $orderProcessor = false;
+
     protected bool $afterTax = false;
 
     public function isAfterTax(): bool
     {
-        return $this->afterTax ?? false;
+        return $this->afterTax;
     }
 
     public function setAfterTax(bool $afterTax): void
     {
         $this->afterTax = $afterTax;
+    }
+
+    public function isOrderProcessor(): bool
+    {
+        return $this->orderProcessor;
+    }
+
+    public function setOrderProcessor(bool $orderProcessor): void
+    {
+        $this->orderProcessor = $orderProcessor;
     }
 }

--- a/src/Context/PromotionContextInterface.php
+++ b/src/Context/PromotionContextInterface.php
@@ -16,4 +16,8 @@ interface PromotionContextInterface
     public function isAfterTax(): bool;
 
     public function setAfterTax(bool $afterTax): void;
+
+    public function isOrderProcessor(): bool;
+
+    public function setOrderProcessor(bool $orderProcessor): void;
 }

--- a/src/Promotion/Checker/Eligibility/PromotionTaxContextEligibilityChecker.php
+++ b/src/Promotion/Checker/Eligibility/PromotionTaxContextEligibilityChecker.php
@@ -32,6 +32,10 @@ final class PromotionTaxContextEligibilityChecker implements PromotionEligibilit
         PromotionSubjectInterface $promotionSubject,
         PromotionInterface $promotion
     ): bool {
+        if (!$this->promotionContext->isOrderProcessor()) {
+            return true;
+        }
+
         /** @var AfterTaxAwareInterface $promotion */
         Assert::isInstanceOf($promotion, AfterTaxAwareInterface::class);
 

--- a/src/Promotion/Decorator/PromotionProcessorDecorator.php
+++ b/src/Promotion/Decorator/PromotionProcessorDecorator.php
@@ -22,7 +22,8 @@ use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
 final class PromotionProcessorDecorator implements PromotionProcessorInterface
 {
     public function __construct(
-        #[AutowireDecorated] private readonly PromotionProcessor $promotionProcessor,
+        #[AutowireDecorated]
+        private readonly PromotionProcessor $promotionProcessor,
         private readonly PromotionContextInterface $promotionContext,
     ) {
     }

--- a/src/Promotion/Decorator/PromotionProcessorDecorator.php
+++ b/src/Promotion/Decorator/PromotionProcessorDecorator.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Advanced Promotion plugin for Sylius.
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusAdvancedPromotionPlugin\Promotion\Decorator;
+
+use MonsieurBiz\SyliusAdvancedPromotionPlugin\Context\PromotionContextInterface;
+use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Sylius\Component\Promotion\Processor\PromotionProcessor;
+use Sylius\Component\Promotion\Processor\PromotionProcessorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
+
+#[AsDecorator('sylius.promotion_processor')]
+final class PromotionProcessorDecorator implements PromotionProcessorInterface
+{
+    public function __construct(
+        #[AutowireDecorated] private readonly PromotionProcessor $promotionProcessor,
+        private readonly PromotionContextInterface $promotionContext,
+    ) {
+    }
+
+    public function process(PromotionSubjectInterface $subject): void
+    {
+        $this->promotionContext->setOrderProcessor(true);
+        $this->promotionContext->setAfterTax(false);
+        $this->promotionProcessor->process($subject);
+    }
+}

--- a/src/Promotion/Processor/AfterTaxPromotionProcessor.php
+++ b/src/Promotion/Processor/AfterTaxPromotionProcessor.php
@@ -36,6 +36,7 @@ final class AfterTaxPromotionProcessor implements PromotionProcessorInterface
     public function process(PromotionSubjectInterface $subject): void
     {
         // Set the promotion context to after cart
+        $this->promotionContext->setOrderProcessor(true);
         $this->promotionContext->setAfterTax(true);
 
         /**

--- a/src/Resources/config/fixtures/advanced_promotion.yaml
+++ b/src/Resources/config/fixtures/advanced_promotion.yaml
@@ -2,8 +2,49 @@ sylius_fixtures:
     suites:
         default:
             fixtures:
+                promotion:
+                    options:
+                        custom:
+                            flash_sales:
+                                code: 'flash_sales'
+                                name: 'Flash sales'
+                                exclusive: false
+                                channels:
+                                    - 'FASHION_WEB'
+                                coupon_based: true
+                                coupons:
+                                    -   code: 'FLASH_SALES'
+                                rules:
+                                    -   type: 'cart_quantity'
+                                        configuration:
+                                            count: 0
+                                actions:
+                                    -   type: 'order_fixed_discount'
+                                        configuration:
+                                            FASHION_WEB:
+                                                amount: 10.00
+                            gift_card:
+                                code: 'gift_card'
+                                name: 'Gift card'
+                                exclusive: false
+                                channels:
+                                    - 'FASHION_WEB'
+                                coupon_based: true
+                                coupons:
+                                    -   code: 'GIFT_CARD'
+                                rules:
+                                    -   type: 'cart_quantity'
+                                        configuration:
+                                            count: 0
+                                actions:
+                                    -   type: 'order_fixed_discount'
+                                        configuration:
+                                            FASHION_WEB:
+                                                amount: 30.00
                 monsieurbiz_advanced_promotion:
                     options:
                         promotion_advanced_configuration:
                             -   code: 'new_year'
+                                after_tax: true
+                            -   code: 'gift_card'
                                 after_tax: true

--- a/src/Resources/config/grids/promotion.yaml
+++ b/src/Resources/config/grids/promotion.yaml
@@ -7,6 +7,11 @@ sylius_grid:
                     label: monsieurbiz_sylius_advanced_promotion.promotion.applied_after_tax
                     options:
                         template: "@SyliusUi/Grid/Field/yesNo.html.twig"
+                channels:
+                    type: twig
+                    label: sylius.ui.channels
+                    options:
+                        template: '@SyliusAdmin/Grid/Field/_channels.html.twig'
             filters:
                 afterTax:
                     type: boolean


### PR DESCRIPTION
## Before

![image](https://github.com/monsieurbiz/SyliusAdvancedPromotionPlugin/assets/11380627/9242462f-d895-4df5-b8b0-3f92c40b765a)

## After

![image](https://github.com/monsieurbiz/SyliusAdvancedPromotionPlugin/assets/11380627/c8e5745d-4a1f-4ee9-8733-bf393b20f116)

## Other features

### Channels in grid

![image](https://github.com/monsieurbiz/SyliusAdvancedPromotionPlugin/assets/11380627/898e8220-50da-4651-a45b-a11930c6202f)

### Coupons rules

One before tax, one after tax with codes `FLASH_SALES` and `GIFT_CARD`.
